### PR TITLE
Added a check for tag

### DIFF
--- a/Penumbra.lua
+++ b/Penumbra.lua
@@ -365,11 +365,15 @@ function Penumbra.display_track()
 end
 
 function Penumbra.get_artist(key, tag)
-	if not SMODS.Sounds[key] then	
+	if not SMODS.Sounds[key] then
 		return "LouisF"
+	end
+	if not tag then
+		return Penumbra.loc_authors[key] or "???"
 	end
 	return Penumbra.loc_authors[key] or tag.artist or "???"
 end
+
 function Penumbra.get_name(key, tag)
 	return (Penumbra.loc_names[key] or (Penumbra.loc_keys[key] and localize(Penumbra.loc_keys[key]))) or tag.title or key or ""
 end


### PR DESCRIPTION
Added a check for `tag`, since it would crash when opening the options for the Mod if it doesn't exist in the .json files, therefore not allowing to check if sounds were loaded correctly.